### PR TITLE
add tags and local template rendering

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,6 +1,8 @@
 ---
 - name: Run the playbook to setup the host metal.
   ansible.builtin.import_playbook: bare_metal_edge_host.yml
+  tags: bare_metal
 
 - name: Run the playbook to setup the EDGE.
   ansible.builtin.import_playbook: edge.yml
+  tags: edge

--- a/ansible/roles/edge/tasks/appliance.yml
+++ b/ansible/roles/edge/tasks/appliance.yml
@@ -6,6 +6,8 @@
     owner: anapaya
     group: users
     mode: "0700"
+  tags:
+  - config
 
 - name: Copy configuration files for appliance-cli
   ansible.builtin.copy:
@@ -17,8 +19,11 @@
   loop:
     - "{{ edge_cli_config_file }}"
     - "{{ edge_cli_context_file }}"
+  tags:
+  - config
 
 - name: Configure appliance
+  tags: config
   module_defaults:
     ansible.builtin.uri:
       force_basic_auth: true
@@ -42,6 +47,7 @@
       changed_when: _this.json != edge_appliance_config.json
 
     - name: Add TRCs
+      tags: trcs
       ansible.builtin.uri:
         url: https://127.0.0.1/api/v1/cppki/trcs/bundle
         method: POST
@@ -55,6 +61,9 @@
       changed_when: _this is not failed
 
 - name: Copy control-plane key and certificate files if they exist locally
+  tags: 
+  - config
+  - keys
   ansible.builtin.copy:
     src: "{{ item.src }}"
     dest: "{{ edge_scion_cert_key_filename_without_suffix }}.{{ item.suffix }}"

--- a/ansible/roles/edge/tasks/main.yml
+++ b/ansible/roles/edge/tasks/main.yml
@@ -1,5 +1,13 @@
 ---
-#- name: Initialize system
-#  ansible.builtin.import_tasks: init.yml
+- name: Initialize system
+  ansible.builtin.import_tasks: init.yml
+  tags:
+  - init
 - name: Configure appliance
   ansible.builtin.import_tasks: appliance.yml
+  tags:
+  - config
+- name: Render appliance config locally
+  ansible.builtin.import_tasks: render_template.yml
+  tags:
+  - render

--- a/ansible/roles/edge/tasks/render_template.yml
+++ b/ansible/roles/edge/tasks/render_template.yml
@@ -1,0 +1,7 @@
+---
+- name: Render template to file
+  template:
+    src: templates/appliance.json.j2
+    dest: /tmp/edge_config.txt
+  tags: render
+

--- a/ansible/roles/routing_to_edge/tasks/bgp.yml
+++ b/ansible/roles/routing_to_edge/tasks/bgp.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure frr is installed
   ansible.builtin.apt:
     name: frr

--- a/ansible/roles/routing_to_edge/tasks/main.yml
+++ b/ansible/roles/routing_to_edge/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: Set up BGP
   ansible.builtin.import_tasks: bgp.yml
+  tags: bgp


### PR DESCRIPTION
add tags to config pushes to allow us to easily only push edge config changes and nothing else

tests:

```
└─[0] <git:(cg/tags 0378f23) > poetry run ansible-playbook -i ewr-host.yml ansible/edge.yml --tags config --list-tasks

playbook: ansible/edge.yml

  play #1 (edge_vms): Configure the EDGE appliance      TAGS: []
    tasks:
      edge : Validating arguments against arg spec 'main'       TAGS: [always]
      edge : Create appliance-cli configuration directory       TAGS: [config]
      edge : Copy configuration files for appliance-cli TAGS: [config]
      edge : Get current appliance configuration        TAGS: [config]
      edge : Put appliance configuration        TAGS: [config]
      edge : Add TRCs   TAGS: [config, trcs]
      edge : Copy control-plane key and certificate files if they exist locally TAGS: [config, keys]
┌─[chrisgorham@Chriss-MacBook-Pro] - [~/github.com/scion-sui-deploy] - [2024-07-26 11:32:20]
└─[0] <git:(cg/tags 0378f23) > poetry run ansible-playbook -i ewr-host.yml ansible/edge.yml --tags trcs --list-tasks

playbook: ansible/edge.yml

  play #1 (edge_vms): Configure the EDGE appliance      TAGS: []
    tasks:
      edge : Validating arguments against arg spec 'main'       TAGS: [always]
      edge : Add TRCs   TAGS: [config, trcs]
┌─[chrisgorham@Chriss-MacBook-Pro] - [~/github.com/scion-sui-deploy] - [2024-07-26 11:32:26]
└─[0] <git:(cg/tags 0378f23) > poetry run ansible-playbook -i ewr-host.yml ansible/edge.yml --tags keys --list-tasks

playbook: ansible/edge.yml

  play #1 (edge_vms): Configure the EDGE appliance      TAGS: []
    tasks:
      edge : Validating arguments against arg spec 'main'       TAGS: [always]
      edge : Copy control-plane key and certificate files if they exist locally TAGS: [config, keys]
 ```