### PR TITLE
Edge Netplan Configuration File

### DIFF
--- a/netplan/99-edge-netplan.yaml
+++ b/netplan/99-edge-netplan.yaml
@@ -1,10 +1,6 @@
 network:
   version: 2
   bridges:
-    virbr_scion:
-      dhcp4: yes
-      addresses:
-        - "192.168.18.2/24"
     scionwan:
       dhcp4: no
       dhcp6: no

--- a/netplan/99-edge-netplan.yaml
+++ b/netplan/99-edge-netplan.yaml
@@ -1,0 +1,24 @@
+network:
+  version: 2
+  bridges:
+    virbr_scion:
+      dhcp4: yes
+      addresses:
+        - "192.168.18.2/24"
+    scionwan:
+      dhcp4: no
+      dhcp6: no
+      interfaces: [enp1s0f1]
+      addresses:
+        - "A.B.C.E/31"
+        - "X::Y/64"
+      nameservers:
+        addresses:
+        - 1.1.1.1
+        - 8.8.8.8
+        - 2001:4860:4860::8888
+      routes:
+        - to: "0.0.0.0/0"
+          via: A.B.C.D
+        - to: "::/0"
+          via: X::1


### PR DESCRIPTION
This file is used as a template for Edge bare metal hardware to set up the required network bridges. It is intended to be used in conjunction with the existing netplan file on the host (as opposed to replacing). 